### PR TITLE
Fix/google oauth backend flow

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -42,6 +42,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-client</artifactId>
+		</dependency>
+
 
 		<dependency>
 			<groupId>com.mysql</groupId>

--- a/backend/src/main/java/com/job/demo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/job/demo/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                         // Allow public access to static uploads (photos/resumes)
                         .requestMatchers("/uploads/**").permitAll()
                         // Allow login and register
-                        .requestMatchers("/api/auth/**", "/login", "/register").permitAll()
+                        .requestMatchers("/api/auth/**","/oauth2/**", "/login", "/register").permitAll()
                         // Secure everything else
                         .anyRequest().authenticated()
                 )
@@ -56,6 +56,9 @@ public class SecurityConfig {
                         .successHandler(successHandler())
                         .failureHandler(failureHandler())
                         .permitAll()
+                )
+                .oauth2Login(oauth -> oauth
+                    .defaultSuccessUrl("http://localhost:5173/feed", true)
                 );
 
         return http.build();

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,3 +17,9 @@ lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Value
 
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+
+
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.scope=openid,profile,email
+spring.security.oauth2.client.provider.google.issuer-uri=https://accounts.google.com

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -117,27 +117,32 @@ const Login = () => {
       setLoading(false);
     }
   };
-  
-  const handleGoogleLogin = (response: CredentialResponse) => {
-    try {
-      if (!response.credential) throw new Error("Missing Google credential");
-      const decoded = jwtDecode<GoogleUser>(response.credential);
-      const user = {
-        id: decoded.sub || "unknown",
-        name: decoded.name || "User",
-        email: decoded.email || "unknown",
-        avatar: decoded.picture,
-      };
-      handleLoginSuccess(response.credential, user);
-      toast.success(`Welcome back, ${user.name}!`);
-      
-      const hasOnboarded = localStorage.getItem("onboarding_completed");
-      navigate(hasOnboarded ? "/feed" : "/onboarding");
-    } catch (err) {
-      console.error("Google login error:", err);
-      toast.error("Google login failed. Please try again.");
-    }
+  const handleGoogleLogin = () => {
+    window.location.href = "http://localhost:8096/oauth2/authorization/google";
   };
+  
+  //   const handleGoogleLogin = (response: CredentialResponse) => {
+  //   try {
+  //     if (!response.credential) throw new Error("Missing Google credential");
+  //     const decoded = jwtDecode<GoogleUser>(response.credential);
+  //     const user = {
+  //       id: decoded.sub || "unknown",
+  //       name: decoded.name || "User",
+  //       email: decoded.email || "unknown",
+  //       avatar: decoded.picture,
+  //     };
+  //     handleLoginSuccess(response.credential, user);
+  //     toast.success(`Welcome back, ${user.name}!`);
+      
+  //     const hasOnboarded = localStorage.getItem("onboarding_completed");
+  //     navigate(hasOnboarded ? "/feed" : "/onboarding");
+  //   } catch (err) {
+  //     console.error("Google login error:", err);
+  //     toast.error("Google login failed. Please try again.");
+  //   }
+  // };
+
+
 
   return (
     <div className="min-h-screen flex items-center justify-center px-4 sm:px-5 py-8 gradient-subtle">
@@ -248,12 +253,13 @@ const Login = () => {
 
           {/* Google Login */}
           <div className="flex justify-center mt-4">
-            <GoogleLogin
-              onSuccess={handleGoogleLogin}
-              onError={() => toast.error("Google login failed")}
-              shape="pill"
-              width="280"
-            />
+            <Button
+              variant="outline"
+              className="w-full flex items-center gap-2"
+              onClick={handleGoogleLogin}
+            >
+              Continue with Google
+            </Button>
           </div>
 
           {/* Footer */}


### PR DESCRIPTION
**Bug Fix**
**Issue Resolved**

Instead of using frontend OAuth (GIS) and sending the token to backend to verify it,
Google can now redirect directly to the backend and process the login.

This ensures a single, backend-controlled OAuth flow where tokens are securely handled by Spring Security, session/state integrity is preserved, frontend logic is simplified, and the risk of token misuse or verification errors is eliminated.

**🔧 Changes Made**

**Backend - In config/Security.config**
Enabled backend-managed Google OAuth by adding: .oauth2Login()
Permitting /oauth2/**

**Frontend - In components/Login.tsx**
Replaced frontend Google OAuth (GIS) using <GoogleLogin /> + jwtDecode
Added a simple redirect-based login:
window.location.href = "/oauth2/authorization/google";

**✅ Final Result**

The OAuth flow works perfectly now.
**⚠️ Note**
As the OAuth consent screen is in testing mode right now, for successful login you will need to create test users.
Once you publish the app, test users won’t longer be required.

**🔍 Key Observation**

Directly accessing http://localhost:5173/feed loads the page without authentication because frontend routes are not protected and do not verify the backend-authenticated session before rendering.

**💡 Suggested Solution**

Protect frontend routes by calling a backend /auth/me (or similar) endpoint on load and redirect unauthenticated users to /login.


Let me know if you have any questions